### PR TITLE
Add the path that the program takes

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -76,16 +76,20 @@ func main() {
   go findPageWithName(startingPage, endingPage, path, pageFound)
   found := <- pageFound
 
+  fmt.Println("===== Begin  =====")
+  fmt.Println("- Begin at:", startingPage)
   for index, urlAndNextStep := range found {
     for url, nextStep := range urlAndNextStep {
       fmt.Println("===== Step", (index + 1), "=====")
-      fmt.Println("Start at:", url)
+      fmt.Println("- Start at:", url)
       if (nextStep == "") {
-        fmt.Println("Click on: [Error - Unknown Next Step]")
+        fmt.Println("- Click on: [Error - Unknown Next Step]")
       } else {
-        fmt.Println("Click on:", nextStep)
+        fmt.Println("- Click on:", nextStep)
       }
     }
   }
+  fmt.Println("===== End    =====")
+  fmt.Println("- End at:", endingPage)
 
 }

--- a/scraper.go
+++ b/scraper.go
@@ -8,31 +8,35 @@ import (
   "strings"
 )
 
+// Receives a URL and returns all of the HTML
 func getUrl(url string) (pageData string){
-  res, err := http.Get(url)
+  res, err := http.Get(url) // Make the request
 
-  if (err != nil) {
+  if (err != nil) { // Request has an error
     return
   }
 
-  bytes, _ := ioutil.ReadAll(res.Body)
-  defer res.Body.Close()
+  bytes, _ := ioutil.ReadAll(res.Body) // Read the request
+  defer res.Body.Close() // Set the request body to close after function return
 
-  return (string(bytes))
+  return (string(bytes)) // Return the webpage HTML
 }
 
+// Extracts the links and the names of the links from Wikipedia page HTML
 func extractUrlsAndNames(html string) (wikipediaUrlsAndNames map[string]string) {
-  wikipediaUrlsAndNames = make(map[string]string)
+  wikipediaUrlsAndNames = make(map[string]string) // This will hold the links and their name
   wikipediaUrlPrefix := "https://en.wikipedia.org"
 
-  untrimmedAnchors := strings.Split(html, "<a href=\"")[1:]
+  untrimmedAnchors := strings.Split(html, "<a href=\"")[1:] // A list of anchor tags that needs to be trimmed down
   for _, untrimmedAnchor := range untrimmedAnchors {
-    url := untrimmedAnchor[:strings.Index(untrimmedAnchor, "\"")]
+    url := untrimmedAnchor[:strings.Index(untrimmedAnchor, "\"")] // Grab the link URL
 
+    // Ignore links that do not start with /wiki or are internal links
     if (strings.HasPrefix(url, "/wiki") && !strings.Contains(url, ":")) {
-      fullUrl := wikipediaUrlPrefix + url
-      name := untrimmedAnchor[strings.Index(untrimmedAnchor, ">") + 1:strings.Index(untrimmedAnchor, "<")]
+      fullUrl := wikipediaUrlPrefix + url // Create the full URL
+      name := untrimmedAnchor[strings.Index(untrimmedAnchor, ">") + 1:strings.Index(untrimmedAnchor, "<")] // Grab the link name
 
+      // Ignore links with internal HTML or the read link at the top of the page
       if (!strings.Contains(name, "<") || name == "Read") {
         wikipediaUrlsAndNames[fullUrl] = name
       }
@@ -42,53 +46,61 @@ func extractUrlsAndNames(html string) (wikipediaUrlsAndNames map[string]string) 
   return wikipediaUrlsAndNames
 }
 
-func findPageWithName(startingPage, endingPage string, path []map[string]string, pageFound chan []map[string]string) {
-  pageHTML := getUrl(startingPage)
-  urls := extractUrlsAndNames(pageHTML)
+// Searches through links on a given Wikipedia page until it finds the ending page
+func findPage(startingPage, endingPage string, path []map[string]string, pageFound chan []map[string]string) {
+  pageHTML := getUrl(startingPage) // Grabs the pages HTML
+  urls := extractUrlsAndNames(pageHTML) // Finds all the links in the HTML
 
+  // Temp holds the path that findPage takes, but it is a copy to ensure that the path of each request is not being appended to the same slice
   temp := make([]map[string]string, len(path))
   copy(temp, path)
 
+  // Traverse all URLs on the page and see if any match the ending page URL
+  // If not, take the URL and run findPage with the new URL as startingPage
   for url, name := range urls {
     select {
-      case <- pageFound:
+      case <- pageFound: // Checks if the page has already been found to end all searching goroutines
         return
       default:
-        temp = append(path, map[string]string {startingPage: name})
-        if (url == endingPage) {
-          pageFound <- temp
-          close(pageFound)
+        temp = append(path, map[string]string {startingPage: name}) // Add the new search to the path
+        if (url == endingPage) { // Found the ending page
+          pageFound <- temp // Send the path through the channel
+          close(pageFound) // Close the channel
           return
         } else {
-          go findPageWithName(url, endingPage, temp, pageFound)
+          go findPage(url, endingPage, temp, pageFound) // Run findPage with the new URL to continue the search
         }
     }
   }
 }
 
 func main() {
+  // Example starting and ending page if none are supplied through command line
   startingPage := "https://en.wikipedia.org/wiki/Pikachu"
   endingPage := "https://en.wikipedia.org/wiki/Central_processing_unit"
 
-  if (len(os.Args) == 3) { // Command line arguments
+  // Starting and ending pages have been supplied through command line
+  if (len(os.Args) == 3) {
     startingPage = os.Args[1]
     endingPage = os.Args[2]
   }
 
-  pageFound := make(chan []map[string]string)
+  pageFound := make(chan []map[string]string) // Create channel to listen for the ending page being found
 
-  var path []map[string]string
+  var path []map[string]string // Create a beginning slice to hold the path that the program takes to reach the ending page
 
-  go findPageWithName(startingPage, endingPage, path, pageFound)
-  found := <- pageFound
+  // Begin finding the page at the starting page
+  go findPage(startingPage, endingPage, path, pageFound)
+  found := <- pageFound // Holds the path from the starting page to the ending page
 
+  // Display the path that the program took
   fmt.Println("===== Begin  =====")
   fmt.Println("- Begin at:", startingPage)
   for index, urlAndNextStep := range found {
     for url, nextStep := range urlAndNextStep {
       fmt.Println("===== Step", (index + 1), "=====")
       fmt.Println("- Start at:", url)
-      if (nextStep == "") {
+      if (nextStep == "") { // Occasional error where there is no next step
         fmt.Println("- Click on: [Error - Unknown Next Step]")
       } else {
         fmt.Println("- Click on:", nextStep)
@@ -97,5 +109,4 @@ func main() {
   }
   fmt.Println("===== End    =====")
   fmt.Println("- End at:", endingPage)
-
 }

--- a/scraper.go
+++ b/scraper.go
@@ -20,6 +20,47 @@ func getUrl(url string) (pageData string){
   return (string(bytes))
 }
 
+func extractUrlsAndNames(html string) (wikipediaUrlsAndNames map[string]string) {
+  wikipediaUrlsAndNames = make(map[string]string)
+  wikipediaUrlPrefix := "https://en.wikipedia.org"
+
+  untrimmedAnchors := strings.Split(html, "<a href=\"")[1:]
+  for _, untrimmedAnchor := range untrimmedAnchors {
+    url := untrimmedAnchor[:strings.Index(untrimmedAnchor, "\"")]
+
+    if (strings.HasPrefix(url, "/wiki") && !strings.Contains(url, ":")) {
+      fullUrl := wikipediaUrlPrefix + url
+      name := untrimmedAnchor[strings.Index(untrimmedAnchor, ">") + 1:strings.Index(untrimmedAnchor, "<")]
+
+      wikipediaUrlsAndNames[fullUrl] = name
+    }
+  }
+
+  return wikipediaUrlsAndNames
+}
+
+func findPageWithName(startingPage, endingPage string, path []map[string]string, pageFound chan []map[string]string) {
+  pageHTML := getUrl(startingPage)
+  urls := extractUrlsAndNames(pageHTML)
+
+  temp := make([]map[string]string, len(path))
+  copy(temp, path)
+
+  for url, name := range urls {
+    temp = append(path, map[string]string {startingPage: name})
+    select {
+      case <- pageFound:
+        return
+      default:
+        if (url == endingPage) {
+          pageFound <- temp
+        } else {
+          go findPageWithName(url, endingPage, temp, pageFound)
+        }
+    }
+  }
+}
+
 func extractUrls(html string) (wikipediaUrls []string) {
   wikipediaUrlPrefix := "https://en.wikipedia.org"
 
@@ -60,14 +101,29 @@ func main() {
   startingPage := "https://en.wikipedia.org/wiki/Pikachu"
   endingPage := "https://en.wikipedia.org/wiki/Central_processing_unit"
 
-  pageFound := make(chan []string)
+  // pageFound := make(chan []string)
+  //
+  // go findPage(startingPage, endingPage, []string{}, pageFound)
+  // found := <- pageFound
+  //
+  // found = append(found, endingPage)
+  //
+  // for index, url := range found {
+  //   fmt.Println("Step", index, ":", url)
+  // }
 
-  go findPage(startingPage, endingPage, []string{}, pageFound)
+  pageFound := make(chan []map[string]string)
+
+  var path []map[string]string
+
+  go findPageWithName(startingPage, endingPage, path, pageFound)
   found := <- pageFound
 
-  found = append(found, endingPage)
-
-  for index, url := range found {
-    fmt.Println("Step", index, ":", url)
+  for index, urlAndNextStep := range found {
+    for url, nextStep := range urlAndNextStep {
+      fmt.Println("===== Step", (index + 1), "=====")
+      fmt.Println("Start at", url, "and click", nextStep)
+    }
   }
+
 }

--- a/scraper.go
+++ b/scraper.go
@@ -2,6 +2,7 @@ package main
 
 import (
   "fmt"
+  "os"
   "io/ioutil"
   "net/http"
   "strings"
@@ -68,6 +69,11 @@ func findPageWithName(startingPage, endingPage string, path []map[string]string,
 func main() {
   startingPage := "https://en.wikipedia.org/wiki/Pikachu"
   endingPage := "https://en.wikipedia.org/wiki/Central_processing_unit"
+
+  if (len(os.Args) == 3) { // Command line arguments
+    startingPage = os.Args[1]
+    endingPage = os.Args[2]
+  }
 
   pageFound := make(chan []map[string]string)
 


### PR DESCRIPTION
The current page and the name of the next link to click on are now displayed once the program has found the ending page. It is still buggy (it does not display the correct path with long paths).